### PR TITLE
構造体のメンバ変数が多すぎる

### DIFF
--- a/atsPlugin/source/ATO/header/ats.h
+++ b/atsPlugin/source/ATO/header/ats.h
@@ -17,7 +17,7 @@ struct Spec		//列車のスペックに関する情報
 	int A = 0;	//ATS確認段数
 	int J = 0;	//常用段数67度相当
 	int C = 0;	//編成車両数
-	int E = 0;	//非常段数
+//	int E = 0;	//非常段数
 };
 struct State		//列車状態に関する情報
 {


### PR DESCRIPTION
## 概要
`DetailManager`で本プラグインを読み込ませるとエラーが発生する

## 原因
 Bveが送ろうとしている構造体とプラグインで定義している構造体のサイズが異なり、スタックを破壊しバスエラーが起きていると思われる。

## 対策
こちらをコメントアウトし、ビルドエラーを修正することによりランタイムエラーが発生しないことを確認した。